### PR TITLE
add ssh_key create command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# VPSM
+A worse version of (HCloud)[https://hetzner.cloud] for now.
+
+## Usage
+```
+vpsm create --name my-server --image ubuntu-22.04 --type cx11 --ssh-key ~/.ssh/id_rsa.pub
+```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # VPSM
-A worse version of (HCloud)[https://hetzner.cloud] for now.
+A worse version of [HCloud](https://hetzner.cloud) for now.
 
 ## Usage
 ```

--- a/cmd/commands/sshkey/add.go
+++ b/cmd/commands/sshkey/add.go
@@ -1,0 +1,204 @@
+package sshkey
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/tabwriter"
+
+	"nathanbeddoewebdev/vpsm/internal/domain"
+	"nathanbeddoewebdev/vpsm/internal/providers"
+	"nathanbeddoewebdev/vpsm/internal/services/auth"
+
+	"github.com/charmbracelet/huh"
+	"github.com/spf13/cobra"
+)
+
+func AddCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add [path]",
+		Short: "Upload an SSH key to the cloud provider",
+		Long: `Upload a local SSH public key to the cloud provider's account.
+
+The path argument is optional and defaults to ~/.ssh/id_ed25519.pub.
+If that file does not exist, you will be prompted to provide a path.
+
+The key name will be prompted interactively unless --name is specified.
+
+Examples:
+  # Upload default key (interactive name prompt)
+  vpsm ssh-key add
+
+  # Upload specific key with explicit name
+  vpsm ssh-key add ~/.ssh/work_laptop.pub --name work-laptop
+
+  # Upload with provider override
+  vpsm ssh-key add --provider hetzner --name my-key`,
+		Run: runAdd,
+	}
+
+	cmd.Flags().String("name", "", "Name for the SSH key (interactive prompt if not provided)")
+
+	return cmd
+}
+
+func runAdd(cmd *cobra.Command, args []string) {
+	providerName := cmd.Flag("provider").Value.String()
+
+	provider, err := providers.Get(providerName, auth.DefaultStore())
+	if err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Error: %v\n", err)
+		return
+	}
+
+	keyManager, ok := provider.(domain.SSHKeyManager)
+	if !ok {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Error: provider %q does not support SSH key management\n", providerName)
+		return
+	}
+
+	// Determine path
+	var keyPath string
+	if len(args) > 0 {
+		keyPath = args[0]
+	} else {
+		keyPath = defaultSSHKeyPath()
+	}
+
+	// Expand home directory if present
+	if strings.HasPrefix(keyPath, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Error: failed to determine home directory: %v\n", err)
+			return
+		}
+		keyPath = filepath.Join(home, keyPath[2:])
+	}
+
+	// Check if file exists
+	if _, err := os.Stat(keyPath); os.IsNotExist(err) {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Error: SSH key file not found: %s\n", keyPath)
+		fmt.Fprintln(cmd.ErrOrStderr(), "\nCommon SSH key paths:")
+		fmt.Fprintln(cmd.ErrOrStderr(), "  ~/.ssh/id_ed25519.pub")
+		fmt.Fprintln(cmd.ErrOrStderr(), "  ~/.ssh/id_rsa.pub")
+		fmt.Fprintln(cmd.ErrOrStderr(), "  ~/.ssh/id_ecdsa.pub")
+		return
+	}
+
+	fmt.Fprintf(cmd.ErrOrStderr(), "Reading key from %s\n", keyPath)
+
+	// Read and validate the SSH key
+	publicKey, err := readAndValidateSSHKey(keyPath)
+	if err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Error: %v\n", err)
+		return
+	}
+
+	// Get or prompt for name
+	keyName, _ := cmd.Flags().GetString("name")
+	if keyName == "" {
+		suggestedName := suggestKeyName(keyPath)
+		accessible := os.Getenv("ACCESSIBLE") != ""
+
+		form := huh.NewForm(
+			huh.NewGroup(
+				huh.NewInput().
+					Title("Enter a name for this SSH key").
+					Value(&keyName).
+					Placeholder(suggestedName).
+					Validate(func(s string) error {
+						if strings.TrimSpace(s) == "" {
+							return fmt.Errorf("name cannot be empty")
+						}
+						return nil
+					}),
+			),
+		).WithAccessible(accessible)
+
+		if err := form.Run(); err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Error: %v\n", err)
+			return
+		}
+	}
+
+	// Upload the key
+	fmt.Fprintf(cmd.ErrOrStderr(), "Uploading SSH key %q to %s...", keyName, provider.GetDisplayName())
+
+	ctx := context.Background()
+	keySpec, err := keyManager.CreateSSHKey(ctx, keyName, publicKey)
+	if err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "\nError: %v\n", err)
+		return
+	}
+
+	fmt.Fprintln(cmd.ErrOrStderr(), " done")
+	fmt.Fprintln(cmd.ErrOrStderr())
+
+	// Print the result
+	printKeyDetails(cmd, keySpec)
+}
+
+func defaultSSHKeyPath() string {
+	return "~/.ssh/id_ed25519.pub"
+}
+
+func readAndValidateSSHKey(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read SSH key file: %w", err)
+	}
+
+	publicKey := strings.TrimSpace(string(data))
+	if publicKey == "" {
+		return "", fmt.Errorf("SSH key file is empty")
+	}
+
+	// Basic validation: check that it looks like a public key
+	if strings.Contains(publicKey, "PRIVATE KEY") {
+		return "", fmt.Errorf("file appears to contain a private key; please provide the public key (.pub file)")
+	}
+
+	// Check for common public key prefixes
+	validPrefixes := []string{"ssh-rsa", "ssh-ed25519", "ssh-dss", "ecdsa-sha2-"}
+	isValid := false
+	for _, prefix := range validPrefixes {
+		if strings.HasPrefix(publicKey, prefix) {
+			isValid = true
+			break
+		}
+	}
+
+	if !isValid {
+		return "", fmt.Errorf("file does not appear to be a valid SSH public key (expected ssh-rsa, ssh-ed25519, or ecdsa-sha2-*)")
+	}
+
+	return publicKey, nil
+}
+
+func suggestKeyName(path string) string {
+	// Extract filename without extension
+	base := filepath.Base(path)
+	name := strings.TrimSuffix(base, filepath.Ext(base))
+
+	// Common substitutions
+	if name == "id_ed25519" || name == "id_rsa" || name == "id_ecdsa" {
+		// Try to get a more meaningful name from hostname
+		if hostname, err := os.Hostname(); err == nil {
+			return hostname
+		}
+	}
+
+	return name
+}
+
+func printKeyDetails(cmd *cobra.Command, key *domain.SSHKeySpec) {
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+	defer w.Flush()
+
+	fmt.Fprintln(w, "SSH key added:")
+	fmt.Fprintf(w, "  Name:\t%s\n", key.Name)
+	fmt.Fprintf(w, "  Fingerprint:\t%s\n", key.Fingerprint)
+	fmt.Fprintf(w, "  ID:\t%s\n", key.ID)
+}

--- a/cmd/commands/sshkey/add_test.go
+++ b/cmd/commands/sshkey/add_test.go
@@ -1,0 +1,307 @@
+package sshkey
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"nathanbeddoewebdev/vpsm/internal/domain"
+	"nathanbeddoewebdev/vpsm/internal/providers"
+	"nathanbeddoewebdev/vpsm/internal/services/auth"
+)
+
+// sshKeyMockProvider implements domain.Provider and domain.SSHKeyManager for testing.
+type sshKeyMockProvider struct {
+	displayName       string
+	createErr         error
+	createdKey        *domain.SSHKeySpec
+	capturedName      string
+	capturedPublicKey string
+}
+
+func (m *sshKeyMockProvider) GetDisplayName() string { return m.displayName }
+
+func (m *sshKeyMockProvider) CreateServer(_ context.Context, opts domain.CreateServerOpts) (*domain.Server, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *sshKeyMockProvider) DeleteServer(_ context.Context, id string) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (m *sshKeyMockProvider) GetServer(_ context.Context, id string) (*domain.Server, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *sshKeyMockProvider) ListServers(_ context.Context) ([]domain.Server, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *sshKeyMockProvider) CreateSSHKey(_ context.Context, name, publicKey string) (*domain.SSHKeySpec, error) {
+	m.capturedName = name
+	m.capturedPublicKey = publicKey
+	if m.createErr != nil {
+		return nil, m.createErr
+	}
+	if m.createdKey != nil {
+		return m.createdKey, nil
+	}
+	return &domain.SSHKeySpec{
+		ID:          "123",
+		Name:        name,
+		Fingerprint: "aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99",
+	}, nil
+}
+
+// registerSSHKeyMockProvider resets the global registry and registers the mock.
+func registerSSHKeyMockProvider(t *testing.T, name string, mock *sshKeyMockProvider) {
+	t.Helper()
+	providers.Reset()
+	t.Cleanup(func() { providers.Reset() })
+	providers.Register(name, func(store auth.Store) (domain.Provider, error) {
+		return mock, nil
+	})
+}
+
+// execAdd creates the ssh-key command, wires up output buffers, runs "add --provider <provider> [args...]",
+// and returns what was written to stdout and stderr.
+func execAdd(t *testing.T, providerName string, extraArgs ...string) (stdout, stderr string) {
+	t.Helper()
+	var outBuf, errBuf bytes.Buffer
+	cmd := NewCommand()
+	cmd.SetOut(&outBuf)
+	cmd.SetErr(&errBuf)
+	args := append([]string{"add", "--provider", providerName}, extraArgs...)
+	cmd.SetArgs(args)
+	cmd.Execute()
+	return outBuf.String(), errBuf.String()
+}
+
+// createTempSSHKey creates a temporary SSH public key file for testing.
+func createTempSSHKey(t *testing.T, content string) string {
+	t.Helper()
+	tmpFile, err := os.CreateTemp("", "test_sshkey_*.pub")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	t.Cleanup(func() { os.Remove(tmpFile.Name()) })
+
+	if _, err := tmpFile.WriteString(content); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		t.Fatalf("failed to close temp file: %v", err)
+	}
+
+	return tmpFile.Name()
+}
+
+func TestAddCommand_WithNameFlag(t *testing.T) {
+	keyContent := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFakeKeyData12345 test@example.com"
+	keyPath := createTempSSHKey(t, keyContent)
+
+	mock := &sshKeyMockProvider{
+		displayName: "Mock",
+	}
+	registerSSHKeyMockProvider(t, "mock", mock)
+
+	stdout, stderr := execAdd(t, "mock", keyPath, "--name", "my-test-key")
+
+	if mock.capturedName != "my-test-key" {
+		t.Errorf("expected CreateSSHKey called with name 'my-test-key', got %q", mock.capturedName)
+	}
+	if !strings.Contains(mock.capturedPublicKey, "ssh-ed25519") {
+		t.Errorf("expected public key to be passed, got %q", mock.capturedPublicKey)
+	}
+	if !strings.Contains(stdout, "SSH key added") {
+		t.Errorf("expected 'SSH key added' on stdout, got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "my-test-key") {
+		t.Errorf("expected key name on stdout, got:\n%s", stdout)
+	}
+	if !strings.Contains(stderr, "Uploading SSH key") {
+		t.Errorf("expected 'Uploading SSH key' on stderr, got:\n%s", stderr)
+	}
+}
+
+func TestAddCommand_RSAKey(t *testing.T) {
+	keyContent := "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC... user@host"
+	keyPath := createTempSSHKey(t, keyContent)
+
+	mock := &sshKeyMockProvider{
+		displayName: "Mock",
+	}
+	registerSSHKeyMockProvider(t, "mock", mock)
+
+	stdout, stderr := execAdd(t, "mock", keyPath, "--name", "rsa-key")
+
+	if !strings.Contains(mock.capturedPublicKey, "ssh-rsa") {
+		t.Errorf("expected RSA key to be captured, got %q", mock.capturedPublicKey)
+	}
+	if !strings.Contains(stdout, "SSH key added") {
+		t.Errorf("expected success message on stdout, got:\n%s", stdout)
+	}
+	if !strings.Contains(stderr, "done") {
+		t.Errorf("expected 'done' message on stderr, got:\n%s", stderr)
+	}
+}
+
+func TestAddCommand_FileNotFound(t *testing.T) {
+	mock := &sshKeyMockProvider{
+		displayName: "Mock",
+	}
+	registerSSHKeyMockProvider(t, "mock", mock)
+
+	_, stderr := execAdd(t, "mock", "/nonexistent/path/key.pub", "--name", "test")
+
+	if !strings.Contains(stderr, "SSH key file not found") {
+		t.Errorf("expected 'file not found' error on stderr, got:\n%s", stderr)
+	}
+	if mock.capturedName != "" {
+		t.Errorf("expected CreateSSHKey not to be called, but it was called with name %q", mock.capturedName)
+	}
+}
+
+func TestAddCommand_InvalidKeyFormat(t *testing.T) {
+	keyContent := "this is not a valid ssh key"
+	keyPath := createTempSSHKey(t, keyContent)
+
+	mock := &sshKeyMockProvider{
+		displayName: "Mock",
+	}
+	registerSSHKeyMockProvider(t, "mock", mock)
+
+	_, stderr := execAdd(t, "mock", keyPath, "--name", "test")
+
+	if !strings.Contains(stderr, "does not appear to be a valid SSH public key") {
+		t.Errorf("expected validation error on stderr, got:\n%s", stderr)
+	}
+	if mock.capturedName != "" {
+		t.Errorf("expected CreateSSHKey not to be called, but it was called")
+	}
+}
+
+func TestAddCommand_PrivateKeyRejected(t *testing.T) {
+	keyContent := "-----BEGIN OPENSSH PRIVATE KEY-----\nfake private key data\n-----END OPENSSH PRIVATE KEY-----"
+	keyPath := createTempSSHKey(t, keyContent)
+
+	mock := &sshKeyMockProvider{
+		displayName: "Mock",
+	}
+	registerSSHKeyMockProvider(t, "mock", mock)
+
+	_, stderr := execAdd(t, "mock", keyPath, "--name", "test")
+
+	if !strings.Contains(stderr, "private key") {
+		t.Errorf("expected private key rejection on stderr, got:\n%s", stderr)
+	}
+	if mock.capturedName != "" {
+		t.Errorf("expected CreateSSHKey not to be called, but it was called")
+	}
+}
+
+func TestAddCommand_CreateError(t *testing.T) {
+	keyContent := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFakeKeyData test@example.com"
+	keyPath := createTempSSHKey(t, keyContent)
+
+	mock := &sshKeyMockProvider{
+		displayName: "Mock",
+		createErr:   fmt.Errorf("duplicate key name"),
+	}
+	registerSSHKeyMockProvider(t, "mock", mock)
+
+	stdout, stderr := execAdd(t, "mock", keyPath, "--name", "duplicate")
+
+	if !strings.Contains(stderr, "duplicate key name") {
+		t.Errorf("expected create error on stderr, got:\n%s", stderr)
+	}
+	if strings.Contains(stdout, "SSH key added") {
+		t.Errorf("expected no success message on stdout, got:\n%s", stdout)
+	}
+}
+
+func TestAddCommand_ProviderNotSupported(t *testing.T) {
+	// Register a provider that doesn't implement SSHKeyManager
+	providers.Reset()
+	t.Cleanup(func() { providers.Reset() })
+
+	basicProvider := &basicMockProvider{displayName: "Basic"}
+	providers.Register("basic", func(store auth.Store) (domain.Provider, error) {
+		return basicProvider, nil
+	})
+
+	keyContent := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFakeKeyData test@example.com"
+	keyPath := createTempSSHKey(t, keyContent)
+
+	_, stderr := execAdd(t, "basic", keyPath, "--name", "test")
+
+	if !strings.Contains(stderr, "does not support SSH key management") {
+		t.Errorf("expected unsupported provider error on stderr, got:\n%s", stderr)
+	}
+}
+
+func TestAddCommand_UnknownProvider(t *testing.T) {
+	providers.Reset()
+	t.Cleanup(func() { providers.Reset() })
+
+	_, stderr := execAdd(t, "nonexistent", "/fake/path", "--name", "test")
+
+	if !strings.Contains(stderr, "unknown provider") {
+		t.Errorf("expected 'unknown provider' error on stderr, got:\n%s", stderr)
+	}
+}
+
+// basicMockProvider implements only domain.Provider (not SSHKeyManager).
+type basicMockProvider struct {
+	displayName string
+}
+
+func (m *basicMockProvider) GetDisplayName() string { return m.displayName }
+func (m *basicMockProvider) CreateServer(_ context.Context, opts domain.CreateServerOpts) (*domain.Server, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (m *basicMockProvider) DeleteServer(_ context.Context, id string) error {
+	return fmt.Errorf("not implemented")
+}
+func (m *basicMockProvider) GetServer(_ context.Context, id string) (*domain.Server, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (m *basicMockProvider) ListServers(_ context.Context) ([]domain.Server, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func TestSuggestKeyName(t *testing.T) {
+	tests := []struct {
+		path        string
+		wantPattern string // Either exact name or "hostname" to indicate hostname fallback
+	}{
+		{"/home/user/.ssh/id_ed25519.pub", "hostname"}, // Common key, falls back to hostname
+		{"/home/user/.ssh/id_rsa.pub", "hostname"},     // Common key, falls back to hostname
+		{"/home/user/.ssh/work_key.pub", "work_key"},   // Custom key, returns base name
+		{"~/.ssh/laptop.pub", "laptop"},                // Custom key, returns base name
+	}
+
+	for _, tc := range tests {
+		got := suggestKeyName(tc.path)
+		if tc.wantPattern == "hostname" {
+			// For common keys, expect hostname (non-empty and not the original name)
+			if got == "" {
+				t.Errorf("suggestKeyName(%q) = empty string, expected hostname", tc.path)
+			}
+			base := filepath.Base(tc.path)
+			baseName := strings.TrimSuffix(base, filepath.Ext(base))
+			if got == baseName {
+				t.Errorf("suggestKeyName(%q) = %q, expected hostname fallback not base name", tc.path, got)
+			}
+		} else {
+			// For custom keys, expect the exact name
+			if got != tc.wantPattern {
+				t.Errorf("suggestKeyName(%q) = %q, expected %q", tc.path, got, tc.wantPattern)
+			}
+		}
+	}
+}

--- a/cmd/commands/sshkey/sshkey.go
+++ b/cmd/commands/sshkey/sshkey.go
@@ -1,0 +1,44 @@
+package sshkey
+
+import (
+	"fmt"
+
+	"nathanbeddoewebdev/vpsm/internal/config"
+
+	"github.com/spf13/cobra"
+)
+
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "ssh-key",
+		Short:             "Manage SSH keys across cloud providers",
+		Long:              `Upload, list, and delete SSH keys from your configured cloud providers.`,
+		PersistentPreRunE: resolveProvider,
+	}
+
+	cmd.AddCommand(AddCommand())
+
+	cmd.PersistentFlags().String("provider", "", "Cloud provider to use (overrides default)")
+
+	return cmd
+}
+
+// resolveProvider ensures the --provider flag has a value, falling back to the
+// configured default when the flag was not explicitly passed.
+func resolveProvider(cmd *cobra.Command, args []string) error {
+	if cmd.Flag("provider").Changed {
+		return nil
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	if cfg.DefaultProvider != "" {
+		cmd.Flag("provider").Value.Set(cfg.DefaultProvider)
+		return nil
+	}
+
+	return fmt.Errorf("no provider specified: use --provider flag or set a default with 'vpsm config set default-provider <name>'")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"nathanbeddoewebdev/vpsm/cmd/commands/auth"
 	cfgcmd "nathanbeddoewebdev/vpsm/cmd/commands/config"
 	"nathanbeddoewebdev/vpsm/cmd/commands/server"
+	"nathanbeddoewebdev/vpsm/cmd/commands/sshkey"
 	"nathanbeddoewebdev/vpsm/internal/providers"
 
 	"github.com/spf13/cobra"
@@ -32,6 +33,7 @@ Quick start:
 	cmd.AddCommand(auth.NewCommand())
 	cmd.AddCommand(cfgcmd.NewCommand())
 	cmd.AddCommand(server.NewCommand())
+	cmd.AddCommand(sshkey.NewCommand())
 
 	return cmd
 }

--- a/internal/domain/provider.go
+++ b/internal/domain/provider.go
@@ -23,3 +23,10 @@ type CatalogProvider interface {
 	ListImages(ctx context.Context) ([]ImageSpec, error)
 	ListSSHKeys(ctx context.Context) ([]SSHKeySpec, error)
 }
+
+// SSHKeyManager extends Provider with SSH key management operations.
+type SSHKeyManager interface {
+	Provider
+
+	CreateSSHKey(ctx context.Context, name, publicKey string) (*SSHKeySpec, error)
+}

--- a/internal/providers/hetzner.go
+++ b/internal/providers/hetzner.go
@@ -17,6 +17,7 @@ import (
 // Compile-time check that HetznerProvider satisfies CatalogProvider
 // (which embeds Provider).
 var _ domain.CatalogProvider = (*HetznerProvider)(nil)
+var _ domain.SSHKeyManager = (*HetznerProvider)(nil)
 
 // HetznerProvider implements domain.Provider using the Hetzner Cloud API.
 type HetznerProvider struct {

--- a/internal/providers/hetzner.go
+++ b/internal/providers/hetzner.go
@@ -21,8 +21,9 @@ var _ domain.SSHKeyManager = (*HetznerProvider)(nil)
 
 // HetznerProvider implements domain.Provider using the Hetzner Cloud API.
 type HetznerProvider struct {
-	client *hcloud.Client
-	cache  *cache.Cache
+	client      *hcloud.Client
+	cache       *cache.Cache
+	retryConfig retry.Config
 }
 
 const (
@@ -38,8 +39,9 @@ func NewHetznerProvider(opts ...hcloud.ClientOption) *HetznerProvider {
 	}
 	allOpts := append(defaults, opts...)
 	return &HetznerProvider{
-		client: hcloud.NewClient(allOpts...),
-		cache:  cache.NewDefault(),
+		client:      hcloud.NewClient(allOpts...),
+		cache:       cache.NewDefault(),
+		retryConfig: retry.DefaultConfig(),
 	}
 }
 
@@ -67,7 +69,7 @@ func (h *HetznerProvider) DeleteServer(ctx context.Context, id string) error {
 		return fmt.Errorf("invalid server ID %q: %w", id, err)
 	}
 
-	err = retry.Do(ctx, retry.DefaultConfig(), isHetznerRetryable, func() error {
+	err = retry.Do(ctx, h.retryConfig, isHetznerRetryable, func() error {
 		reqCtx, cancel := context.WithTimeout(ctx, requestTimeout)
 		defer cancel()
 		_, _, err := h.client.Server.DeleteWithResult(reqCtx, &hcloud.Server{ID: numericID})
@@ -97,7 +99,7 @@ func (h *HetznerProvider) GetServer(ctx context.Context, id string) (*domain.Ser
 	}
 
 	var hzServer *hcloud.Server
-	err = retry.Do(ctx, retry.DefaultConfig(), isHetznerRetryable, func() error {
+	err = retry.Do(ctx, h.retryConfig, isHetznerRetryable, func() error {
 		reqCtx, cancel := context.WithTimeout(ctx, requestTimeout)
 		defer cancel()
 		var apiErr error
@@ -125,7 +127,7 @@ func (h *HetznerProvider) GetServer(ctx context.Context, id string) (*domain.Ser
 // ListServers retrieves all servers from the Hetzner Cloud API.
 func (h *HetznerProvider) ListServers(ctx context.Context) ([]domain.Server, error) {
 	var hzServers []*hcloud.Server
-	err := retry.Do(ctx, retry.DefaultConfig(), isHetznerRetryable, func() error {
+	err := retry.Do(ctx, h.retryConfig, isHetznerRetryable, func() error {
 		reqCtx, cancel := context.WithTimeout(ctx, requestTimeout)
 		defer cancel()
 		var apiErr error
@@ -204,7 +206,6 @@ func isHetznerRetryable(err error) bool {
 		hcloud.ErrorCodeServerError,
 		hcloud.ErrorCodeTimeout,
 		hcloud.ErrorCodeUnknownError,
-		hcloud.ErrorCodeConflict,
 		hcloud.ErrorCodeResourceUnavailable,
 		hcloud.ErrorCodeMaintenance,
 		hcloud.ErrorCodeRobotUnavailable,

--- a/internal/providers/hetzner_catalog.go
+++ b/internal/providers/hetzner_catalog.go
@@ -26,7 +26,7 @@ func (h *HetznerProvider) ListLocations(ctx context.Context) ([]domain.Location,
 	}
 
 	var hzLocations []*hcloud.Location
-	err := retry.Do(ctx, retry.DefaultConfig(), isHetznerRetryable, func() error {
+	err := retry.Do(ctx, h.retryConfig, isHetznerRetryable, func() error {
 		reqCtx, cancel := context.WithTimeout(ctx, requestTimeout)
 		defer cancel()
 		var apiErr error
@@ -60,7 +60,7 @@ func (h *HetznerProvider) ListServerTypes(ctx context.Context) ([]domain.ServerT
 	}
 
 	var hzServerTypes []*hcloud.ServerType
-	err := retry.Do(ctx, retry.DefaultConfig(), isHetznerRetryable, func() error {
+	err := retry.Do(ctx, h.retryConfig, isHetznerRetryable, func() error {
 		reqCtx, cancel := context.WithTimeout(ctx, requestTimeout)
 		defer cancel()
 		var apiErr error
@@ -94,7 +94,7 @@ func (h *HetznerProvider) ListImages(ctx context.Context) ([]domain.ImageSpec, e
 	}
 
 	var hzImages []*hcloud.Image
-	err := retry.Do(ctx, retry.DefaultConfig(), isHetznerRetryable, func() error {
+	err := retry.Do(ctx, h.retryConfig, isHetznerRetryable, func() error {
 		reqCtx, cancel := context.WithTimeout(ctx, requestTimeout)
 		defer cancel()
 		var apiErr error
@@ -122,7 +122,7 @@ func (h *HetznerProvider) ListImages(ctx context.Context) ([]domain.ImageSpec, e
 // ListSSHKeys retrieves all SSH keys from the Hetzner Cloud API.
 func (h *HetznerProvider) ListSSHKeys(ctx context.Context) ([]domain.SSHKeySpec, error) {
 	var hzKeys []*hcloud.SSHKey
-	err := retry.Do(ctx, retry.DefaultConfig(), isHetznerRetryable, func() error {
+	err := retry.Do(ctx, h.retryConfig, isHetznerRetryable, func() error {
 		reqCtx, cancel := context.WithTimeout(ctx, requestTimeout)
 		defer cancel()
 		var apiErr error
@@ -146,7 +146,7 @@ func (h *HetznerProvider) ListSSHKeys(ctx context.Context) ([]domain.SSHKeySpec,
 // CreateSSHKey uploads a new SSH key to the Hetzner Cloud API.
 func (h *HetznerProvider) CreateSSHKey(ctx context.Context, name, publicKey string) (*domain.SSHKeySpec, error) {
 	var hzKey *hcloud.SSHKey
-	err := retry.Do(ctx, retry.DefaultConfig(), isHetznerRetryable, func() error {
+	err := retry.Do(ctx, h.retryConfig, isHetznerRetryable, func() error {
 		reqCtx, cancel := context.WithTimeout(ctx, requestTimeout)
 		defer cancel()
 		var apiErr error

--- a/internal/providers/hetzner_create.go
+++ b/internal/providers/hetzner_create.go
@@ -31,7 +31,7 @@ func (h *HetznerProvider) CreateServer(ctx context.Context, opts domain.CreateSe
 	// each name-or-ID through the API before creating the server.
 	for _, key := range opts.SSHKeys {
 		var sshKey *hcloud.SSHKey
-		err := retry.Do(ctx, retry.DefaultConfig(), isHetznerRetryable, func() error {
+		err := retry.Do(ctx, h.retryConfig, isHetznerRetryable, func() error {
 			reqCtx, cancel := context.WithTimeout(ctx, requestTimeout)
 			defer cancel()
 			var apiErr error

--- a/internal/providers/hetzner_test.go
+++ b/internal/providers/hetzner_test.go
@@ -12,6 +12,7 @@ import (
 
 	"nathanbeddoewebdev/vpsm/internal/cache"
 	"nathanbeddoewebdev/vpsm/internal/domain"
+	"nathanbeddoewebdev/vpsm/internal/retry"
 	"nathanbeddoewebdev/vpsm/internal/services/auth"
 
 	"github.com/google/go-cmp/cmp"
@@ -29,6 +30,7 @@ func newTestHetznerProvider(t *testing.T, serverURL string, token string) *Hetzn
 		hcloud.WithToken(token),
 	)
 	provider.cache = cache.New(t.TempDir())
+	provider.retryConfig = retry.Config{MaxAttempts: 3}
 	return provider
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added SSH key management to the CLI, enabling users to add and manage SSH keys for their configured cloud provider via the `ssh-key add` command.

* **Documentation**
  * Added README with overview and usage examples for the tool.

* **Tests**
  * Added comprehensive test coverage for SSH key management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->