### PR TITLE
Add PostHog analytics with download click tracking

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -16,6 +16,13 @@
         <title>
             VPSM - A VPS and app deployment interface for the terminal.
         </title>
+        <script>
+            !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group identify setPersonProperties setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags resetGroups onFeatureFlags addFeatureFlagsHandler onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+            posthog.init('phc_zMsfKRMiRwzeAt8DOH0lDRPbEKJWl4CAMGGnMfJjqtD', {
+                api_host: 'https://eu.i.posthog.com',
+                defaults: '2026-01-30'
+            })
+        </script>
     </head>
     <body>
         <main class="container">
@@ -59,35 +66,35 @@
                             <td>macOS</td>
                             <td>Apple Silicon (arm64)</td>
                             <td>
-                                <a href="https://github.com/NathanBeddoeWebDev/vpsm/releases/latest/download/vpsm-darwin-arm64">vpsm-darwin-arm64</a>
+                                <a href="https://github.com/NathanBeddoeWebDev/vpsm/releases/latest/download/vpsm-darwin-arm64" onclick="posthog.capture('download_clicked', { os: 'macOS', arch: 'arm64', binary: 'vpsm-darwin-arm64' })">vpsm-darwin-arm64</a>
                             </td>
                         </tr>
                         <tr>
                             <td>macOS</td>
                             <td>Intel (amd64)</td>
                             <td>
-                                <a href="https://github.com/NathanBeddoeWebDev/vpsm/releases/latest/download/vpsm-darwin-amd64">vpsm-darwin-amd64</a>
+                                <a href="https://github.com/NathanBeddoeWebDev/vpsm/releases/latest/download/vpsm-darwin-amd64" onclick="posthog.capture('download_clicked', { os: 'macOS', arch: 'amd64', binary: 'vpsm-darwin-amd64' })">vpsm-darwin-amd64</a>
                             </td>
                         </tr>
                         <tr>
                             <td>Linux</td>
                             <td>x86_64 (amd64)</td>
                             <td>
-                                <a href="https://github.com/NathanBeddoeWebDev/vpsm/releases/latest/download/vpsm-linux-amd64">vpsm-linux-amd64</a>
+                                <a href="https://github.com/NathanBeddoeWebDev/vpsm/releases/latest/download/vpsm-linux-amd64" onclick="posthog.capture('download_clicked', { os: 'Linux', arch: 'amd64', binary: 'vpsm-linux-amd64' })">vpsm-linux-amd64</a>
                             </td>
                         </tr>
                         <tr>
                             <td>Linux</td>
                             <td>ARM64</td>
                             <td>
-                                <a href="https://github.com/NathanBeddoeWebDev/vpsm/releases/latest/download/vpsm-linux-arm64">vpsm-linux-arm64</a>
+                                <a href="https://github.com/NathanBeddoeWebDev/vpsm/releases/latest/download/vpsm-linux-arm64" onclick="posthog.capture('download_clicked', { os: 'Linux', arch: 'arm64', binary: 'vpsm-linux-arm64' })">vpsm-linux-arm64</a>
                             </td>
                         </tr>
                         <tr>
                             <td>Windows</td>
                             <td>x86_64 (amd64)</td>
                             <td>
-                                <a href="https://github.com/NathanBeddoeWebDev/vpsm/releases/latest/download/vpsm-windows-amd64.exe">vpsm-windows-amd64.exe</a>
+                                <a href="https://github.com/NathanBeddoeWebDev/vpsm/releases/latest/download/vpsm-windows-amd64.exe" onclick="posthog.capture('download_clicked', { os: 'Windows', arch: 'amd64', binary: 'vpsm-windows-amd64.exe' })">vpsm-windows-amd64.exe</a>
                             </td>
                         </tr>
                     </tbody>


### PR DESCRIPTION
Integrate PostHog snippet in the <head> and add 'download_clicked' event capture on each binary download link with os, arch, and binary properties.

https://claude.ai/code/session_01Frjh4yLro4dxEiUZRY4pVL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated analytics tracking to monitor download activity and measure user engagement with binary releases across multiple operating systems and computing architectures, enabling better insights into usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->