### PR TITLE
Add lazy loading to screenshot images

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -135,13 +135,14 @@ vpsm --help</code></pre>
                         <img
                             src="/public/images/Create-Demo.png"
                             alt="Server create wizard"
+                            loading="lazy"
                         />
                     </figure>
                     <figure class="example-card">
-                        <img src="/public/images/Show-Demo.png" alt="Server list" />
+                        <img src="/public/images/Show-Demo.png" alt="Server list" loading="lazy" />
                     </figure>
                     <figure class="example-card example-card--full">
-                        <img src="/public/images/SSH-Demo.png" alt="SSH Connection Screen" />
+                        <img src="/public/images/SSH-Demo.png" alt="SSH Connection Screen" loading="lazy" />
                     </figure>
                 </div>
             </div>


### PR DESCRIPTION
Added the native 'loading=lazy' attribute to all three screenshot images
in the Examples section to improve page load performance and reduce initial
bandwidth usage by deferring image loading until they're needed.

https://claude.ai/code/session_018owG5zwvkJj7DGVQzHphdj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Examples gallery performance by enabling lazy loading for images, reducing initial page load time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->