### PR TITLE
Add Cloudflare domain availability search

### DIFF
--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -25,9 +25,9 @@
 - Cloudflare API v4 - Domain listing, DNS record CRUD, domain search
   - SDK: Direct HTTP client (no SDK, intentionally lightweight)
   - Base URL: `https://api.cloudflare.com/client/v4`
-  - Auth: Scoped Account API Token (not Global API Key) stored under key `cloudflare`
-  - Required permissions: Zone:Read, DNS:Edit; Account:Read + Registrar for domain search
-  - Account ID is auto-discovered from the token on first search call and cached per instance.
+  - Auth: Two keychain entries - `cloudflare` (scoped Account API Token) and `cloudflare-account-id` (Account ID)
+  - Required permissions: Zone:Read, DNS:Edit; Registrar for domain search
+  - Account ID is optional at login time but required for the domain search command; DNS operations work without it.
   - Provider: `internal/dns/providers/cloudflare.go`
   - Timeout: 30s
 
@@ -85,10 +85,11 @@ Each registry maps a normalized provider name to a `Factory` function that takes
 
 **Credential Specs:**
 - Defined in `internal/platform/providers/credentials.go`
-- Three registered providers:
+- Registered providers:
   - Hetzner: single API token
   - Porkbun: API key + secret API key (two keychain entries)
-  - Cloudflare: single Account API Token
+  - Cloudflare: Account API Token + Account ID (two keychain entries)
+  - Vercel: single API token
 
 **Login Flow:**
 - `vpsm auth login <provider>` prompts for credentials based on the provider's `CredentialSpec`
@@ -128,7 +129,8 @@ Each registry maps a normalized provider name to a `Factory` function that takes
 **Required credentials (stored in OS keychain, not env vars):**
 - Hetzner: API token (for server/SSH key operations)
 - Porkbun: API key + secret API key (for DNS operations)
-- Cloudflare: Account API token with Zone:Read + DNS:Edit (for DNS operations)
+- Cloudflare: Account API token with Zone:Read + DNS:Edit (for DNS operations); Account ID + Registrar permission required for domain search
+- Vercel: API token (for DNS operations and domain search)
 
 **No `.env` files:** This application does not use environment variables for configuration. All secrets are stored in the OS keychain and all config is in `~/.config/vpsm/config.json`.
 

--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -22,11 +22,12 @@
   - Provider: `internal/dns/providers/porkbun.go`
   - Timeout: 30s
 
-- Cloudflare API v4 - Domain listing, DNS record CRUD
+- Cloudflare API v4 - Domain listing, DNS record CRUD, domain search
   - SDK: Direct HTTP client (no SDK, intentionally lightweight)
   - Base URL: `https://api.cloudflare.com/client/v4`
   - Auth: Scoped Account API Token (not Global API Key) stored under key `cloudflare`
-  - Required permissions: Zone:Read, DNS:Edit
+  - Required permissions: Zone:Read, DNS:Edit; Account:Read + Registrar for domain search
+  - Account ID is auto-discovered from the token on first search call and cached per instance.
   - Provider: `internal/dns/providers/cloudflare.go`
   - Timeout: 30s
 

--- a/cmd/commands/auth/login.go
+++ b/cmd/commands/auth/login.go
@@ -24,11 +24,12 @@ func LoginCommand() *cobra.Command {
 		Short: "Store credentials for a provider",
 		Long: `Store credentials for a provider using the local keychain.
 
-For single-token providers (e.g. Hetzner, Cloudflare, Vercel), you will be prompted for an API token.
-For multi-credential providers (e.g. Porkbun), you will be prompted for each key.
+For single-token providers (e.g. Hetzner, Vercel), you will be prompted for an API token.
+For multi-credential providers (e.g. Porkbun, Cloudflare), you will be prompted for each key.
 
 Cloudflare requires a scoped Account API Token (not a Global API Key)
-with Zone:Read and DNS:Edit permissions.
+with Zone:Read and DNS:Edit permissions, plus your Account ID. To also
+use domain search, the token needs the Registrar permission.
 
 Vercel requires a Bearer Token from your Vercel account settings.
 

--- a/internal/dns/providers/cloudflare.go
+++ b/internal/dns/providers/cloudflare.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"sync"
 	"time"
 
 	"nathanbeddoewebdev/vpsm/internal/dns/domain"
@@ -16,9 +15,10 @@ import (
 )
 
 const (
-	cloudflareBaseURL    = "https://api.cloudflare.com/client/v4"
-	cloudflareTimeout    = 30 * time.Second
-	cloudflareTokenStore = "cloudflare"
+	cloudflareBaseURL        = "https://api.cloudflare.com/client/v4"
+	cloudflareTimeout        = 30 * time.Second
+	cloudflareTokenStore     = "cloudflare"
+	cloudflareAccountIDStore = "cloudflare-account-id"
 )
 
 // Compile-time checks that CloudflareProvider satisfies domain.Provider
@@ -30,25 +30,26 @@ var (
 
 // CloudflareProvider implements domain.Provider using the Cloudflare API v4.
 // It authenticates via a scoped Account API Token (not a Global API Key).
-// The token needs Zone:Read and DNS:Edit permissions. Domain search also
-// requires Account:Read (for account discovery) and Registrar permissions.
+// The token needs Zone:Read and DNS:Edit permissions; domain search
+// additionally requires the Registrar permission and a stored account ID.
 // It uses a direct HTTP client rather than the official SDK to keep the
 // dependency tree light and the code consistent with other providers.
 type CloudflareProvider struct {
-	token   string
-	baseURL string
-	client  *http.Client
-
-	accountMu sync.Mutex
-	accountID string
+	token     string
+	accountID string // optional; required for domain search
+	baseURL   string
+	client    *http.Client
 }
 
-// NewCloudflareProvider creates a CloudflareProvider with the given Account API Token.
-func NewCloudflareProvider(token string) *CloudflareProvider {
+// NewCloudflareProvider creates a CloudflareProvider with the given Account API
+// Token and optional account ID. The account ID is only required for domain
+// search operations via the Registrar API.
+func NewCloudflareProvider(token, accountID string) *CloudflareProvider {
 	return &CloudflareProvider{
-		token:   token,
-		baseURL: cloudflareBaseURL,
-		client:  &http.Client{Timeout: cloudflareTimeout},
+		token:     token,
+		accountID: accountID,
+		baseURL:   cloudflareBaseURL,
+		client:    &http.Client{Timeout: cloudflareTimeout},
 	}
 }
 
@@ -59,7 +60,8 @@ func RegisterCloudflare() {
 		if err != nil {
 			return nil, fmt.Errorf("cloudflare auth: token not found (run 'vpsm auth login cloudflare'): %w", err)
 		}
-		return NewCloudflareProvider(token), nil
+		accountID, _ := store.GetToken(cloudflareAccountIDStore) // optional; needed for domain search
+		return NewCloudflareProvider(token, accountID), nil
 	})
 }
 
@@ -140,12 +142,6 @@ type cfUpdateRecordBody struct {
 	TTL      int     `json:"ttl,omitempty"`
 	Priority *int    `json:"priority,omitempty"`
 	Comment  *string `json:"comment,omitempty"`
-}
-
-// cfAccount is a minimal Cloudflare account object used for account discovery.
-type cfAccount struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
 }
 
 // cfDomainCheckBody is the request body for the registrar domain-check endpoint.
@@ -476,44 +472,16 @@ func (c *CloudflareProvider) DeleteRecord(ctx context.Context, domainName string
 
 // --- Domain search ---
 
-// resolveAccountID returns the Cloudflare account ID associated with the
-// configured API token. The result is cached on the provider so the lookup
-// happens at most once per provider instance. If the token has access to
-// multiple accounts, the first one returned by the API is used.
-func (c *CloudflareProvider) resolveAccountID(ctx context.Context) (string, error) {
-	c.accountMu.Lock()
-	defer c.accountMu.Unlock()
-
-	if c.accountID != "" {
-		return c.accountID, nil
-	}
-
-	var out cfListEnvelope[cfAccount]
-	status, err := c.doJSONWithStatus(ctx, http.MethodGet, "/accounts?per_page=1", nil, &out)
-	if err != nil {
-		return "", fmt.Errorf("failed to resolve account id: %w", err)
-	}
-	if apiErr := envelopeError(out.Success, out.Errors, status); apiErr != nil {
-		return "", fmt.Errorf("failed to resolve account id: %w", apiErr)
-	}
-	if len(out.Result) == 0 {
-		return "", fmt.Errorf("no accounts accessible to token: %w", domain.ErrUnauthorized)
-	}
-
-	c.accountID = out.Result[0].ID
-	return c.accountID, nil
-}
-
 // CheckAvailability checks whether a domain is available for registration via
-// the Cloudflare Registrar API. The configured API token must have Registrar
-// permissions and Account:Read (for automatic account resolution).
+// the Cloudflare Registrar API. The provider must be configured with an
+// account ID (stored under the "cloudflare-account-id" keychain key) and the
+// API token must have Registrar permissions.
 func (c *CloudflareProvider) CheckAvailability(ctx context.Context, domainName string) (*domain.SearchResult, error) {
-	accountID, err := c.resolveAccountID(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to check availability for %q: %w", domainName, err)
+	if c.accountID == "" {
+		return nil, fmt.Errorf("cloudflare: account ID required for domain search (run 'vpsm auth login cloudflare')")
 	}
 
-	path := fmt.Sprintf("/accounts/%s/registrar/domain-check", accountID)
+	path := fmt.Sprintf("/accounts/%s/registrar/domain-check", c.accountID)
 	body := cfDomainCheckBody{Domains: []string{domainName}}
 
 	var out cfEnvelope[cfDomainCheckResult]

--- a/internal/dns/providers/cloudflare.go
+++ b/internal/dns/providers/cloudflare.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"nathanbeddoewebdev/vpsm/internal/dns/domain"
@@ -20,18 +21,26 @@ const (
 	cloudflareTokenStore = "cloudflare"
 )
 
-// Compile-time check that CloudflareProvider satisfies domain.Provider.
-var _ domain.Provider = (*CloudflareProvider)(nil)
+// Compile-time checks that CloudflareProvider satisfies domain.Provider
+// and domain.SearchProvider.
+var (
+	_ domain.Provider       = (*CloudflareProvider)(nil)
+	_ domain.SearchProvider = (*CloudflareProvider)(nil)
+)
 
 // CloudflareProvider implements domain.Provider using the Cloudflare API v4.
 // It authenticates via a scoped Account API Token (not a Global API Key).
-// The token needs Zone:Read and DNS:Edit permissions.
+// The token needs Zone:Read and DNS:Edit permissions. Domain search also
+// requires Account:Read (for account discovery) and Registrar permissions.
 // It uses a direct HTTP client rather than the official SDK to keep the
 // dependency tree light and the code consistent with other providers.
 type CloudflareProvider struct {
 	token   string
 	baseURL string
 	client  *http.Client
+
+	accountMu sync.Mutex
+	accountID string
 }
 
 // NewCloudflareProvider creates a CloudflareProvider with the given Account API Token.
@@ -131,6 +140,38 @@ type cfUpdateRecordBody struct {
 	TTL      int     `json:"ttl,omitempty"`
 	Priority *int    `json:"priority,omitempty"`
 	Comment  *string `json:"comment,omitempty"`
+}
+
+// cfAccount is a minimal Cloudflare account object used for account discovery.
+type cfAccount struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// cfDomainCheckBody is the request body for the registrar domain-check endpoint.
+type cfDomainCheckBody struct {
+	Domains []string `json:"domains"`
+}
+
+// cfDomainCheckPricing holds pricing info from the registrar check response.
+type cfDomainCheckPricing struct {
+	Currency         string `json:"currency"`
+	RegistrationCost string `json:"registration_cost"`
+	RenewalCost      string `json:"renewal_cost"`
+}
+
+// cfDomainCheck is a single domain entry in the registrar check response.
+type cfDomainCheck struct {
+	Name        string                `json:"name"`
+	Registrable bool                  `json:"registrable"`
+	Tier        string                `json:"tier"`
+	Pricing     *cfDomainCheckPricing `json:"pricing,omitempty"`
+	Reason      string                `json:"reason,omitempty"`
+}
+
+// cfDomainCheckResult wraps the list of domain check entries.
+type cfDomainCheckResult struct {
+	Domains []cfDomainCheck `json:"domains"`
 }
 
 // --- HTTP helpers ---
@@ -431,6 +472,74 @@ func (c *CloudflareProvider) DeleteRecord(ctx context.Context, domainName string
 	}
 
 	return nil
+}
+
+// --- Domain search ---
+
+// resolveAccountID returns the Cloudflare account ID associated with the
+// configured API token. The result is cached on the provider so the lookup
+// happens at most once per provider instance. If the token has access to
+// multiple accounts, the first one returned by the API is used.
+func (c *CloudflareProvider) resolveAccountID(ctx context.Context) (string, error) {
+	c.accountMu.Lock()
+	defer c.accountMu.Unlock()
+
+	if c.accountID != "" {
+		return c.accountID, nil
+	}
+
+	var out cfListEnvelope[cfAccount]
+	status, err := c.doJSONWithStatus(ctx, http.MethodGet, "/accounts?per_page=1", nil, &out)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve account id: %w", err)
+	}
+	if apiErr := envelopeError(out.Success, out.Errors, status); apiErr != nil {
+		return "", fmt.Errorf("failed to resolve account id: %w", apiErr)
+	}
+	if len(out.Result) == 0 {
+		return "", fmt.Errorf("no accounts accessible to token: %w", domain.ErrUnauthorized)
+	}
+
+	c.accountID = out.Result[0].ID
+	return c.accountID, nil
+}
+
+// CheckAvailability checks whether a domain is available for registration via
+// the Cloudflare Registrar API. The configured API token must have Registrar
+// permissions and Account:Read (for automatic account resolution).
+func (c *CloudflareProvider) CheckAvailability(ctx context.Context, domainName string) (*domain.SearchResult, error) {
+	accountID, err := c.resolveAccountID(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check availability for %q: %w", domainName, err)
+	}
+
+	path := fmt.Sprintf("/accounts/%s/registrar/domain-check", accountID)
+	body := cfDomainCheckBody{Domains: []string{domainName}}
+
+	var out cfEnvelope[cfDomainCheckResult]
+	status, err := c.doJSONWithStatus(ctx, http.MethodPost, path, body, &out)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check availability for %q: %w", domainName, err)
+	}
+	if apiErr := envelopeError(out.Success, out.Errors, status); apiErr != nil {
+		return nil, fmt.Errorf("failed to check availability for %q: %w", domainName, apiErr)
+	}
+
+	if len(out.Result.Domains) == 0 {
+		return nil, fmt.Errorf("failed to check availability for %q: empty response", domainName)
+	}
+
+	d := out.Result.Domains[0]
+	result := &domain.SearchResult{
+		Domain:    d.Name,
+		Available: d.Registrable,
+	}
+	if d.Pricing != nil {
+		result.Price = d.Pricing.RegistrationCost
+		result.Renewal = d.Pricing.RenewalCost
+		result.Currency = d.Pricing.Currency
+	}
+	return result, nil
 }
 
 // --- Conversion helpers ---

--- a/internal/dns/providers/cloudflare_test.go
+++ b/internal/dns/providers/cloudflare_test.go
@@ -603,6 +603,200 @@ func TestCloudflare_DeleteRecord_NotFound(t *testing.T) {
 	}
 }
 
+// --- CheckAvailability tests ---
+
+func TestCloudflare_CheckAvailability_Available(t *testing.T) {
+	var capturedBody cfDomainCheckBody
+	var capturedPath string
+	srv := newCFRouter(t, map[string]http.HandlerFunc{
+		"GET /accounts": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(cfSuccessListEnvelope([]any{
+				map[string]any{"id": "acct-123", "name": "Test Account"},
+			}, 1, 1, 1))
+		},
+		"POST /accounts/acct-123/registrar/domain-check": func(w http.ResponseWriter, r *http.Request) {
+			capturedPath = r.URL.Path
+			json.NewDecoder(r.Body).Decode(&capturedBody)
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(cfSuccessEnvelope(map[string]any{
+				"domains": []any{
+					map[string]any{
+						"name":        "newdomain.com",
+						"registrable": true,
+						"tier":        "standard",
+						"pricing": map[string]any{
+							"currency":          "USD",
+							"registration_cost": "9.77",
+							"renewal_cost":      "9.77",
+						},
+					},
+				},
+			}))
+		},
+	})
+
+	p := newTestCloudflareProvider(t, srv.URL)
+
+	result, err := p.CheckAvailability(context.Background(), "newdomain.com")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	want := &domain.SearchResult{
+		Domain:    "newdomain.com",
+		Available: true,
+		Price:     "9.77",
+		Renewal:   "9.77",
+		Currency:  "USD",
+	}
+
+	if diff := cmp.Diff(want, result); diff != "" {
+		t.Errorf("CheckAvailability mismatch (-want +got):\n%s", diff)
+	}
+
+	if capturedPath != "/accounts/acct-123/registrar/domain-check" {
+		t.Errorf("expected check path with account id, got %s", capturedPath)
+	}
+	if len(capturedBody.Domains) != 1 || capturedBody.Domains[0] != "newdomain.com" {
+		t.Errorf("expected body domains=[newdomain.com], got %+v", capturedBody.Domains)
+	}
+}
+
+func TestCloudflare_CheckAvailability_Taken(t *testing.T) {
+	srv := newCFRouter(t, map[string]http.HandlerFunc{
+		"GET /accounts": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(cfSuccessListEnvelope([]any{
+				map[string]any{"id": "acct-123", "name": "Test Account"},
+			}, 1, 1, 1))
+		},
+		"POST /accounts/acct-123/registrar/domain-check": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(cfSuccessEnvelope(map[string]any{
+				"domains": []any{
+					map[string]any{
+						"name":        "google.com",
+						"registrable": false,
+						"reason":      "not_available",
+					},
+				},
+			}))
+		},
+	})
+
+	p := newTestCloudflareProvider(t, srv.URL)
+
+	result, err := p.CheckAvailability(context.Background(), "google.com")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Available {
+		t.Error("expected Available=false for taken domain")
+	}
+	if result.Domain != "google.com" {
+		t.Errorf("Domain = %q, want %q", result.Domain, "google.com")
+	}
+}
+
+func TestCloudflare_CheckAvailability_CachesAccountID(t *testing.T) {
+	accountsCalls := 0
+	srv := newCFRouter(t, map[string]http.HandlerFunc{
+		"GET /accounts": func(w http.ResponseWriter, r *http.Request) {
+			accountsCalls++
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(cfSuccessListEnvelope([]any{
+				map[string]any{"id": "acct-123", "name": "Test Account"},
+			}, 1, 1, 1))
+		},
+		"POST /accounts/acct-123/registrar/domain-check": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(cfSuccessEnvelope(map[string]any{
+				"domains": []any{
+					map[string]any{"name": "a.com", "registrable": true},
+				},
+			}))
+		},
+	})
+
+	p := newTestCloudflareProvider(t, srv.URL)
+
+	for i := 0; i < 3; i++ {
+		if _, err := p.CheckAvailability(context.Background(), "a.com"); err != nil {
+			t.Fatalf("call %d: unexpected error: %v", i, err)
+		}
+	}
+
+	if accountsCalls != 1 {
+		t.Errorf("expected /accounts to be called once (cached), got %d calls", accountsCalls)
+	}
+}
+
+func TestCloudflare_CheckAvailability_NoAccounts(t *testing.T) {
+	srv := newCFRouter(t, map[string]http.HandlerFunc{
+		"GET /accounts": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(cfSuccessListEnvelope([]any{}, 1, 1, 0))
+		},
+	})
+
+	p := newTestCloudflareProvider(t, srv.URL)
+
+	_, err := p.CheckAvailability(context.Background(), "example.com")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, domain.ErrUnauthorized) {
+		t.Errorf("expected ErrUnauthorized, got: %v", err)
+	}
+}
+
+func TestCloudflare_CheckAvailability_Unauthorized(t *testing.T) {
+	srv := newCFRouter(t, map[string]http.HandlerFunc{
+		"GET /accounts": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			json.NewEncoder(w).Encode(cfErrorEnvelope(9109, "Invalid access token"))
+		},
+	})
+
+	p := newTestCloudflareProvider(t, srv.URL)
+
+	_, err := p.CheckAvailability(context.Background(), "example.com")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, domain.ErrUnauthorized) {
+		t.Errorf("expected ErrUnauthorized, got: %v", err)
+	}
+}
+
+func TestCloudflare_CheckAvailability_APIError(t *testing.T) {
+	srv := newCFRouter(t, map[string]http.HandlerFunc{
+		"GET /accounts": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(cfSuccessListEnvelope([]any{
+				map[string]any{"id": "acct-123", "name": "Test Account"},
+			}, 1, 1, 1))
+		},
+		"POST /accounts/acct-123/registrar/domain-check": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusTooManyRequests)
+			json.NewEncoder(w).Encode(cfErrorEnvelope(10013, "Rate limit exceeded"))
+		},
+	})
+
+	p := newTestCloudflareProvider(t, srv.URL)
+
+	_, err := p.CheckAvailability(context.Background(), "example.com")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, domain.ErrRateLimited) {
+		t.Errorf("expected ErrRateLimited, got: %v", err)
+	}
+}
+
 // --- Auth header tests ---
 
 func TestCloudflare_BearerTokenSent(t *testing.T) {

--- a/internal/dns/providers/cloudflare_test.go
+++ b/internal/dns/providers/cloudflare_test.go
@@ -19,9 +19,10 @@ import (
 // --- Test helpers ---
 
 // newTestCloudflareProvider creates a CloudflareProvider pointed at the given test server.
+// The account ID is pre-populated so search tests don't need to mock account discovery.
 func newTestCloudflareProvider(t *testing.T, serverURL string) *CloudflareProvider {
 	t.Helper()
-	p := NewCloudflareProvider("test-token")
+	p := NewCloudflareProvider("test-token", "acct-123")
 	p.baseURL = serverURL
 	return p
 }
@@ -609,12 +610,6 @@ func TestCloudflare_CheckAvailability_Available(t *testing.T) {
 	var capturedBody cfDomainCheckBody
 	var capturedPath string
 	srv := newCFRouter(t, map[string]http.HandlerFunc{
-		"GET /accounts": func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(cfSuccessListEnvelope([]any{
-				map[string]any{"id": "acct-123", "name": "Test Account"},
-			}, 1, 1, 1))
-		},
 		"POST /accounts/acct-123/registrar/domain-check": func(w http.ResponseWriter, r *http.Request) {
 			capturedPath = r.URL.Path
 			json.NewDecoder(r.Body).Decode(&capturedBody)
@@ -665,12 +660,6 @@ func TestCloudflare_CheckAvailability_Available(t *testing.T) {
 
 func TestCloudflare_CheckAvailability_Taken(t *testing.T) {
 	srv := newCFRouter(t, map[string]http.HandlerFunc{
-		"GET /accounts": func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(cfSuccessListEnvelope([]any{
-				map[string]any{"id": "acct-123", "name": "Test Account"},
-			}, 1, 1, 1))
-		},
 		"POST /accounts/acct-123/registrar/domain-check": func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(cfSuccessEnvelope(map[string]any{
@@ -699,61 +688,21 @@ func TestCloudflare_CheckAvailability_Taken(t *testing.T) {
 	}
 }
 
-func TestCloudflare_CheckAvailability_CachesAccountID(t *testing.T) {
-	accountsCalls := 0
-	srv := newCFRouter(t, map[string]http.HandlerFunc{
-		"GET /accounts": func(w http.ResponseWriter, r *http.Request) {
-			accountsCalls++
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(cfSuccessListEnvelope([]any{
-				map[string]any{"id": "acct-123", "name": "Test Account"},
-			}, 1, 1, 1))
-		},
-		"POST /accounts/acct-123/registrar/domain-check": func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(cfSuccessEnvelope(map[string]any{
-				"domains": []any{
-					map[string]any{"name": "a.com", "registrable": true},
-				},
-			}))
-		},
-	})
-
-	p := newTestCloudflareProvider(t, srv.URL)
-
-	for i := 0; i < 3; i++ {
-		if _, err := p.CheckAvailability(context.Background(), "a.com"); err != nil {
-			t.Fatalf("call %d: unexpected error: %v", i, err)
-		}
-	}
-
-	if accountsCalls != 1 {
-		t.Errorf("expected /accounts to be called once (cached), got %d calls", accountsCalls)
-	}
-}
-
-func TestCloudflare_CheckAvailability_NoAccounts(t *testing.T) {
-	srv := newCFRouter(t, map[string]http.HandlerFunc{
-		"GET /accounts": func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(cfSuccessListEnvelope([]any{}, 1, 1, 0))
-		},
-	})
-
-	p := newTestCloudflareProvider(t, srv.URL)
+func TestCloudflare_CheckAvailability_MissingAccountID(t *testing.T) {
+	p := NewCloudflareProvider("test-token", "")
 
 	_, err := p.CheckAvailability(context.Background(), "example.com")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-	if !errors.Is(err, domain.ErrUnauthorized) {
-		t.Errorf("expected ErrUnauthorized, got: %v", err)
+	if !strings.Contains(err.Error(), "account ID required") {
+		t.Errorf("expected 'account ID required' in error, got: %v", err)
 	}
 }
 
 func TestCloudflare_CheckAvailability_Unauthorized(t *testing.T) {
 	srv := newCFRouter(t, map[string]http.HandlerFunc{
-		"GET /accounts": func(w http.ResponseWriter, r *http.Request) {
+		"POST /accounts/acct-123/registrar/domain-check": func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusUnauthorized)
 			json.NewEncoder(w).Encode(cfErrorEnvelope(9109, "Invalid access token"))
@@ -771,14 +720,8 @@ func TestCloudflare_CheckAvailability_Unauthorized(t *testing.T) {
 	}
 }
 
-func TestCloudflare_CheckAvailability_APIError(t *testing.T) {
+func TestCloudflare_CheckAvailability_RateLimited(t *testing.T) {
 	srv := newCFRouter(t, map[string]http.HandlerFunc{
-		"GET /accounts": func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(cfSuccessListEnvelope([]any{
-				map[string]any{"id": "acct-123", "name": "Test Account"},
-			}, 1, 1, 1))
-		},
 		"POST /accounts/acct-123/registrar/domain-check": func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusTooManyRequests)
@@ -828,6 +771,7 @@ func TestCloudflare_Registry_RegisterAndGet(t *testing.T) {
 
 	store := auth.NewMockStore()
 	store.SetToken(cloudflareTokenStore, "cf-test-token")
+	store.SetToken(cloudflareAccountIDStore, "acct-xyz")
 
 	RegisterCloudflare()
 
@@ -837,6 +781,37 @@ func TestCloudflare_Registry_RegisterAndGet(t *testing.T) {
 	}
 	if p.GetDisplayName() != "Cloudflare" {
 		t.Errorf("GetDisplayName = %q, want %q", p.GetDisplayName(), "Cloudflare")
+	}
+
+	cf, ok := p.(*CloudflareProvider)
+	if !ok {
+		t.Fatalf("expected *CloudflareProvider, got %T", p)
+	}
+	if cf.accountID != "acct-xyz" {
+		t.Errorf("accountID = %q, want %q", cf.accountID, "acct-xyz")
+	}
+}
+
+func TestCloudflare_Registry_MissingAccountIDIsOptional(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+
+	store := auth.NewMockStore()
+	store.SetToken(cloudflareTokenStore, "cf-test-token")
+	// No account ID set — provider should still load for DNS operations.
+
+	RegisterCloudflare()
+
+	p, err := Get("cloudflare", store)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	cf, ok := p.(*CloudflareProvider)
+	if !ok {
+		t.Fatalf("expected *CloudflareProvider, got %T", p)
+	}
+	if cf.accountID != "" {
+		t.Errorf("accountID = %q, want empty", cf.accountID)
 	}
 }
 

--- a/internal/platform/providers/credentials.go
+++ b/internal/platform/providers/credentials.go
@@ -65,6 +65,7 @@ var knownSpecs = []CredentialSpec{
 		DisplayName: "Cloudflare",
 		Keys: []CredentialKey{
 			{Key: "", Prompt: "Account API Token (not Global API Key)", Secret: true},
+			{Key: "account-id", Prompt: "Account ID", Secret: false},
 		},
 	},
 	{


### PR DESCRIPTION
Implements SearchProvider for Cloudflare using the Registrar API's
domain-check endpoint. Account ID is auto-discovered from the token via
GET /accounts and cached per provider instance, preserving the existing
single-token login UX.

Requires the token to have Account:Read and Registrar permissions in
addition to the existing Zone:Read and DNS:Edit.